### PR TITLE
test: vitest for writeContract

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@evmts/core": "^0.2.0",

--- a/test/WagmiMintExample.test.ts
+++ b/test/WagmiMintExample.test.ts
@@ -36,6 +36,16 @@ describe("WagmiMintExample", function () {
     console.log(receipt.contractAddress);
     const data = await publicClient.readContract(WagmiMintExample.read({ chainId: `${hardhat.id}` }).balanceOf(accounts[0]));
     expect(data).toEqual(0n);
+
+    // Try mint function
+
+    // Doesn't work
     await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(),account: accounts[0]});
+    // Works
+    await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(1n),account: accounts[0]});
+
+    // Assert that the balance is now 1
+    const afterMint = await publicClient.readContract(WagmiMintExample.read({ chainId: `${hardhat.id}` }).balanceOf(accounts[0]));
+    expect(afterMint).toEqual(1n);
   });
 });

--- a/test/WagmiMintExample.test.ts
+++ b/test/WagmiMintExample.test.ts
@@ -36,6 +36,6 @@ describe("WagmiMintExample", function () {
     console.log(receipt.contractAddress);
     const data = await publicClient.readContract(WagmiMintExample.read({ chainId: `${hardhat.id}` }).balanceOf(accounts[0]));
     expect(data).toEqual(0n);
-    // const x = await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(),account: accounts[0]});
+    await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(),account: accounts[0]});
   });
 });

--- a/test/WagmiMintExample.test.ts
+++ b/test/WagmiMintExample.test.ts
@@ -34,7 +34,8 @@ describe("WagmiMintExample", function () {
     });
     const receipt = await publicClient.waitForTransactionReceipt({ hash });
     console.log(receipt.contractAddress);
-    console.log(WagmiMintExample.read({ chainId: `${hardhat.id}` }).balanceOf(
-      `0x0000000000FFe8B47B3e2130213B802212439497` as Address))
+    const data = await publicClient.readContract(WagmiMintExample.read({ chainId: `${hardhat.id}` }).balanceOf(accounts[0]));
+    expect(data).toEqual(0n);
+    // const x = await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(),account: accounts[0]});
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "solcVersion": "0.8.20"
       }
     ],
-    "target": "es6",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Testing for contract writes

Pending bug description:
```
    // Doesn't work
    await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(),account: accounts[0]});
    // Works
    await walletClient.writeContract({...WagmiMintExample.write({ chainId: `${hardhat.id}` }).mint(1n),account: accounts[0]});

```

Updated: 
Pending bug types for the below
https://github.com/evmts/evmts-monorepo/blob/main/core/src/contract/contract.ts#L18