### PR TITLE
Remove unused import on contract and create type for supported chains.

### DIFF
--- a/src/contracts/WagmiMintExample.sol
+++ b/src/contracts/WagmiMintExample.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Base64.sol";
 

--- a/src/wagmi.ts
+++ b/src/wagmi.ts
@@ -33,4 +33,6 @@ export const config = createConfig({
 	webSocketPublicClient,
 })
 
-export { chains }
+type SupportedChainIds = `${typeof chains[number]["id"]}`;
+
+export { chains, type SupportedChainIds }

--- a/src/wagmi/WagmiEvents.tsx
+++ b/src/wagmi/WagmiEvents.tsx
@@ -1,11 +1,11 @@
 import { WagmiMintExample } from '../contracts/WagmiMintExample.sol'
 import { useReducer } from 'react'
-import { useAccount, useBlockNumber, useContractEvent, useNetwork } from 'wagmi'
+import { useAccount, useBlockNumber, useChainId, useContractEvent, useNetwork } from 'wagmi'
+import { SupportedChainIds } from '../wagmi'
 
 export const WagmiEvents = () => {
-	const { chain } = useNetwork()
 	// in future versian of evmts this will work without casting to string
-	const chainId = String(chain?.id ?? '1') as '1' | '420'
+	const chainId = String(useChainId()) as SupportedChainIds
 
 	const { address } = useAccount()
 

--- a/src/wagmi/WagmiReads.tsx
+++ b/src/wagmi/WagmiReads.tsx
@@ -1,10 +1,10 @@
 import { WagmiMintExample } from '../contracts/WagmiMintExample.sol'
-import { Address, useAccount, useContractRead, useNetwork } from 'wagmi'
+import { Address, useAccount, useChainId, useContractRead, useNetwork } from 'wagmi'
+import { SupportedChainIds } from '../wagmi'
 
 export const WagmiReads = () => {
-	const { chain } = useNetwork()
 	// in future versian of evmts this will work without casting to string
-	const chainId = String(chain?.id ?? '1') as '1' | '420'
+	const chainId = String(useChainId()) as SupportedChainIds
 
 	const { address, isConnected } = useAccount()
 

--- a/src/wagmi/WagmiWrites.tsx
+++ b/src/wagmi/WagmiWrites.tsx
@@ -3,16 +3,17 @@ import { getRandomInt } from '../utils/getRandomInt'
 import {
 	Address,
 	useAccount,
+	useChainId,
 	useContractRead,
 	useContractWrite,
 	useNetwork,
 	useWaitForTransaction,
 } from 'wagmi'
+import { SupportedChainIds } from '../wagmi'
 
 export const WagmiWrites = () => {
-	const { chain } = useNetwork()
 	// in future versian of evmts this will work without casting to string
-	const chainId = String(chain?.id ?? '1') as '1' | '420'
+	const chainId = String(useChainId()) as SupportedChainIds
 
 	const { address, isConnected } = useAccount()
 


### PR DESCRIPTION
ERC721Enumerable was unused in the contract. If we create a type for supported chain ids we can reduce copy paste and also don't have to update it when adding a new chain.